### PR TITLE
Add ACME plugin to proxy

### DIFF
--- a/docker-compose.full-node.yml
+++ b/docker-compose.full-node.yml
@@ -40,6 +40,14 @@ services:
     environment:
       - WS_URL=wss://polygon-da-explorer.matic.today/ws
 
+  # Redis is used to store certificates
+  redis:
+    container_name: redis
+    image:  redis:6-alpine
+    command: "redis-server --save 60 1"
+    volumes:
+      - ./volume/redis/data:/data
+
   proxy:
     container_name: proxy
     image: kong:2.6.0-alpine
@@ -47,8 +55,8 @@ services:
     depends_on:
       - full_node
       - dapp
+      - redis
     volumes:
-      - ./volume/proxy/certs/:/proxy/certs:ro
       - ./volume/proxy/kong.yml:/proxy/kong.yml:ro
     ports:
       - 443:8443

--- a/env/proxy.env
+++ b/env/proxy.env
@@ -9,3 +9,6 @@ KONG_ADMIN_LISTEN=0.0.0.0:8001
 # Proxy DB-less & Declarative
 KONG_DATABASE=off
 KONG_DECLARATIVE_CONFIG=/proxy/kong.yml
+
+# Acme Plugin
+KONG_LUA_SSL_TRUSTED_CERTIFICATE=system

--- a/volume/proxy/kong.yml
+++ b/volume/proxy/kong.yml
@@ -21,9 +21,8 @@ services:
      paths: ["/ws"]
      request_buffering: false
      response_buffering: false
-     snis: ["polygon-da-explorer.matic.today"]
      strip_path: true
-     preserve_host: true
+     # preserve_host: true
  
  - name: dapp 
    url: http://dapp
@@ -34,16 +33,25 @@ services:
      paths: ["/"]
      request_buffering: false
      response_buffering: false
-     snis: ["polygon-da-explorer.matic.today"]
-     preserve_host: true
-    
-certificates:
-  - tags: ["da"]
-    cert: |
-      -----BEGIN CERTIFICATE-----
-      -----END CERTIFICATE-----
-    key: |
-      -----BEGIN PRIVATE KEY-----
-      -----END PRIVATE KEY-----
-    snis:
-      - name: "polygon-da-explorer.matic.today"
+     strip_path: true
+     # preserve_host: true
+
+ - name: acme-dummy
+   url: http://127.0.0.1:65535
+   routes:
+   - name: acme-dummy
+     protocols: ["http"]
+     paths: ["/.well-known/acme-challenge"]
+
+
+plugins:
+  - name: acme
+    config:
+      account_email: miguel@polygon.technology
+      domains: ["polygon-da-explorer.matic.today"]
+      tos_accepted: true
+      # api_uri: https://acme-staging-v02.api.letsencrypt.org/directory
+      storage: "redis"
+      storage_config:
+        redis:
+          host: redis


### PR DESCRIPTION
- [x] Add `ACME` plugin: Auto-renew certificates from `Let's Encrypt`.
- [x]  Add `Redis` as Certificate Storage.